### PR TITLE
Some picture was collapsed without type of image file

### DIFF
--- a/src/main/java/net/coobird/thumbnailator/filters/Rotation.java
+++ b/src/main/java/net/coobird/thumbnailator/filters/Rotation.java
@@ -98,7 +98,7 @@ public class Rotation
 				
 				int newWidth = (int)Math.round(maxX - minX);
 				int newHeight = (int)Math.round(maxY - minY);
-				newImage = new BufferedImageBuilder(newWidth, newHeight).build();
+				newImage = new BufferedImageBuilder(newWidth, newHeight, img.getType()).build();
 				
 				Graphics2D g = newImage.createGraphics();
 				


### PR DESCRIPTION
I have encountered the bug that some JPG picture was collapsed when I execute rotate(angle).
How about of using the default image type?
