### PR TITLE
Add 'scaleUp' option

### DIFF
--- a/src/main/java/net/coobird/thumbnailator/ThumbnailParameter.java
+++ b/src/main/java/net/coobird/thumbnailator/ThumbnailParameter.java
@@ -98,6 +98,12 @@ public class ThumbnailParameter
 	private final boolean keepAspectRatio;
 	
 	/**
+	 * Indicates whether or not the thumbnail should be scaled up in case the
+	 * specified size is bigger than source image's size.
+	 */
+	private final boolean scaleUp;
+
+	/**
 	 * The output format for the thumbnail.
 	 * <p>
 	 * A value of {@link ThumbnailParameter#ORIGINAL_FORMAT} indicates that the
@@ -259,6 +265,7 @@ public class ThumbnailParameter
 			double heightScalingFactor,
 			Region sourceRegion,
 			boolean keepAspectRatio,
+			boolean scaleUp,
 			String outputFormat,
 			String outputFormatType,
 			float outputQuality,
@@ -276,6 +283,8 @@ public class ThumbnailParameter
 		
 		this.keepAspectRatio = keepAspectRatio;
 		
+		this.scaleUp = scaleUp;
+
 		this.sourceRegion = sourceRegion;
 		this.outputFormat = outputFormat;
 		this.outputFormatType = outputFormatType;
@@ -428,6 +437,7 @@ public class ThumbnailParameter
 			Dimension thumbnailSize,
 			Region sourceRegion,
 			boolean keepAspectRatio,
+			boolean scaleUp,
 			String outputFormat,
 			String outputFormatType,
 			float outputQuality,
@@ -444,6 +454,7 @@ public class ThumbnailParameter
 				Double.NaN,
 				sourceRegion,
 				keepAspectRatio,
+				scaleUp,
 				outputFormat,
 				outputFormatType,
 				outputQuality,
@@ -541,6 +552,7 @@ public class ThumbnailParameter
 			double heightScalingFactor,
 			Region sourceRegion,
 			boolean keepAspectRatio,
+			boolean scaleUp,
 			String outputFormat,
 			String outputFormatType,
 			float outputQuality,
@@ -557,6 +569,7 @@ public class ThumbnailParameter
 				heightScalingFactor,
 				sourceRegion,
 				keepAspectRatio,
+				scaleUp,
 				outputFormat,
 				outputFormatType,
 				outputQuality,
@@ -648,6 +661,7 @@ public class ThumbnailParameter
 			Dimension thumbnailSize,
 			Region sourceRegion,
 			boolean keepAspectRatio,
+			boolean scaleUp,
 			String outputFormat,
 			String outputFormatType,
 			float outputQuality,
@@ -664,6 +678,7 @@ public class ThumbnailParameter
 				Double.NaN,
 				sourceRegion,
 				keepAspectRatio,
+				scaleUp,
 				outputFormat,
 				outputFormatType,
 				outputQuality,
@@ -762,6 +777,7 @@ public class ThumbnailParameter
 			double heightScalingFactor,
 			Region sourceRegion,
 			boolean keepAspectRatio,
+			boolean scaleUp,
 			String outputFormat,
 			String outputFormatType,
 			float outputQuality,
@@ -778,6 +794,7 @@ public class ThumbnailParameter
 				heightScalingFactor,
 				sourceRegion,
 				keepAspectRatio,
+				scaleUp,
 				outputFormat,
 				outputFormatType,
 				outputQuality,
@@ -863,6 +880,18 @@ public class ThumbnailParameter
 	{
 		return keepAspectRatio;
 	}
+
+    /**
+     * Returns whether or not the thumbnail should be scaled up in case the
+     * specified size is bigger than source image's size.
+     *
+     * @return      {@code true} if the thumbnail should be scaled up,
+     *              {@code false} otherwise.
+     */
+    public boolean isScaleUp()
+    {
+        return scaleUp;
+    }
 
 	/**
 	 * Returns the output format for the thumbnail.

--- a/src/main/java/net/coobird/thumbnailator/Thumbnailator.java
+++ b/src/main/java/net/coobird/thumbnailator/Thumbnailator.java
@@ -89,6 +89,7 @@ public final class Thumbnailator
 				new FixedSizeThumbnailMaker()
 					.size(destinationWidth, destinationHeight)
 					.keepAspectRatio(param.isKeepAspectRatio())
+					.scaleUp(param.isScaleUp())
 					.fitWithinDimensions(param.fitWithinDimenions())
 					.imageType(imageType)
 					.resizerFactory(param.getResizerFactory())

--- a/src/main/java/net/coobird/thumbnailator/Thumbnails.java
+++ b/src/main/java/net/coobird/thumbnailator/Thumbnails.java
@@ -714,6 +714,7 @@ instance.asFiles("path/to/thumbnail");
 			DITHERING("dithering"),
 			RENDERING("rendering"),
 			KEEP_ASPECT_RATIO("keepAspectRatio"),
+			SCALE_UP("scaleUp"),
 			OUTPUT_FORMAT("outputFormat"),
 			OUTPUT_FORMAT_TYPE("outputFormatType"),
 			OUTPUT_QUALITY("outputQuality"),
@@ -759,6 +760,7 @@ instance.asFiles("path/to/thumbnail");
 			statusMap.put(Properties.DITHERING, Status.OPTIONAL);
 			statusMap.put(Properties.RENDERING, Status.OPTIONAL);
 			statusMap.put(Properties.KEEP_ASPECT_RATIO, Status.OPTIONAL);
+			statusMap.put(Properties.SCALE_UP, Status.OPTIONAL);
 			statusMap.put(Properties.OUTPUT_FORMAT, Status.OPTIONAL);
 			statusMap.put(Properties.OUTPUT_FORMAT_TYPE, Status.OPTIONAL);
 			statusMap.put(Properties.OUTPUT_QUALITY, Status.OPTIONAL);
@@ -819,6 +821,7 @@ instance.asFiles("path/to/thumbnail");
 		
 		private int imageType = IMAGE_TYPE_UNSPECIFIED;
 		private boolean keepAspectRatio = true;
+		private boolean scaleUp = true;
 		
 		private String outputFormat = ThumbnailParameter.DETERMINE_FORMAT;
 		private String outputFormatType = ThumbnailParameter.DEFAULT_FORMAT_TYPE;
@@ -1581,6 +1584,21 @@ Thumbnails.of(image)
 		}
 		
 		/**
+		 * Sets whether or not the thumbnail should be scaled up in case specified size
+		 * is bigger than source image's size.
+		 *
+		 * @param scaleUp         Whether or not to scale up the thumbnail in case
+		 *                        thumbnail's size is bigger than original image.
+		 * @return                Reference to this object.
+		 */
+		public Builder<T> scaleUp(boolean scaleUp)
+		{
+		    updateStatus(Properties.SCALE_UP, Status.ALREADY_SET);
+		    this.scaleUp = scaleUp;
+		    return this;
+		}
+
+		/**
 		 * Sets the output quality of the compression algorithm used to
 		 * compress the thumbnail when it is written to an external destination
 		 * such as a file or output stream.
@@ -2178,6 +2196,7 @@ watermark(Positions.CENTER, image, opacity);
 						new Dimension(width, height),
 						sourceRegion,
 						keepAspectRatio,
+						scaleUp,
 						outputFormat,
 						outputFormatType,
 						outputQuality,
@@ -2196,6 +2215,7 @@ watermark(Positions.CENTER, image, opacity);
 						scaleHeight,
 						sourceRegion,
 						keepAspectRatio,
+						scaleUp,
 						outputFormat,
 						outputFormatType,
 						outputQuality,

--- a/src/main/java/net/coobird/thumbnailator/builders/ThumbnailParameterBuilder.java
+++ b/src/main/java/net/coobird/thumbnailator/builders/ThumbnailParameterBuilder.java
@@ -65,6 +65,7 @@ public final class ThumbnailParameterBuilder
 	private double heightScalingFactor = Double.NaN;
 	private int imageType = ThumbnailParameter.DEFAULT_IMAGE_TYPE;
 	private boolean keepAspectRatio = true;
+	private boolean scaleUp = true;
 	private float thumbnailQuality = ThumbnailParameter.DEFAULT_QUALITY;
 	private String thumbnailFormat = ThumbnailParameter.ORIGINAL_FORMAT;
 	private String thumbnailFormatType = ThumbnailParameter.DEFAULT_FORMAT_TYPE;
@@ -204,6 +205,20 @@ public final class ThumbnailParameterBuilder
 		this.keepAspectRatio = keep;
 		return this;
 	}
+
+    /**
+     * Sets whether or not the thumbnail should be scaled up in case specified
+     * size is bigger than source image's size.
+     *
+     * @param scaleUp   Whether or not to scale up the thumbnail in case
+     *                  thumbnail's size is bigger than original image.
+     * @return          A reference to this object.
+     */
+    public ThumbnailParameterBuilder scaleUp(boolean scaleUp)
+    {
+        this.scaleUp = scaleUp;
+        return this;
+    }
 	
 	/**
 	 * Sets the compression quality setting of the thumbnail.
@@ -369,6 +384,7 @@ public final class ThumbnailParameterBuilder
 					heightScalingFactor,
 					sourceRegion,
 					keepAspectRatio,
+					scaleUp,
 					thumbnailFormat,
 					thumbnailFormatType,
 					thumbnailQuality,
@@ -386,6 +402,7 @@ public final class ThumbnailParameterBuilder
 					new Dimension(width, height),
 					sourceRegion,
 					keepAspectRatio,
+					scaleUp,
 					thumbnailFormat,
 					thumbnailFormatType,
 					thumbnailQuality,

--- a/src/main/java/net/coobird/thumbnailator/makers/FixedSizeThumbnailMaker.java
+++ b/src/main/java/net/coobird/thumbnailator/makers/FixedSizeThumbnailMaker.java
@@ -52,6 +52,7 @@ public final class FixedSizeThumbnailMaker extends ThumbnailMaker
 	private int width;
 	private int height;
 	private boolean keepRatio;
+	private boolean scaleUp = true;
 	private boolean fitWithinDimensions;
 	
 	/**
@@ -207,6 +208,20 @@ public final class FixedSizeThumbnailMaker extends ThumbnailMaker
 		return this;
 	}
 	
+    /**
+     * Sets whether or not the thumbnail should be scaled up in case specified
+     * size is bigger than source image's size
+     *
+     * @param scaleUp   Whether or not to scale up the thumbnail in case
+     *                  thumbnail's size is bigger than original image.
+     * @return          A reference to this object.
+     */
+    public FixedSizeThumbnailMaker scaleUp(boolean scaleUp)
+    {
+        this.scaleUp = scaleUp;
+        return this;
+    }
+
 	/**
 	 * Sets whether or not the thumbnail should fit within the specified
 	 * dimensions.
@@ -252,11 +267,20 @@ public final class FixedSizeThumbnailMaker extends ThumbnailMaker
 		int targetWidth = this.width;
 		int targetHeight = this.height;
 
+        int sourceWidth = img.getWidth();
+        int sourceHeight = img.getHeight();
+
+        if (!scaleUp)
+        {
+            if (sourceWidth < targetWidth && sourceHeight < targetHeight)
+            {
+                targetWidth = sourceWidth;
+                targetHeight = sourceHeight;
+            }
+        }
+
 		if (keepRatio)
 		{
-			int sourceWidth = img.getWidth();
-			int sourceHeight = img.getHeight();
-			
 			double sourceRatio = (double)sourceWidth / (double)sourceHeight;
 			double targetRatio = (double)targetWidth / (double)targetHeight;
 			

--- a/src/test/java/net/coobird/thumbnailator/makers/FixedSizeThumbnailMakerTest.java
+++ b/src/test/java/net/coobird/thumbnailator/makers/FixedSizeThumbnailMakerTest.java
@@ -912,5 +912,58 @@ public class FixedSizeThumbnailMakerTest
 		assertEquals(10, thumbnail.getWidth());
 		assertEquals(10, thumbnail.getHeight());
 	}	
-	
+
+	@Test
+	public void scaledUp_ScaleUpEnabledFitWithinTrue()
+	{
+	    // given
+	    BufferedImage img = new BufferedImageBuilder(100, 99).build();
+
+	    // when
+	    BufferedImage thumbnail = new FixedSizeThumbnailMaker(200, 200)
+	    .keepAspectRatio(true)
+	    .fitWithinDimensions(true)
+	    //.scaleUp(true) // scale up should be enabled by default
+	    .make(img);
+
+	    // then
+	    assertEquals(200, thumbnail.getWidth());
+	    assertEquals(198, thumbnail.getHeight());
+	}
+
+	@Test
+	public void scaledUp_ScaleUpDisabledFitWithinTrue()
+	{
+	    // given
+	    BufferedImage img = new BufferedImageBuilder(100, 99).build();
+
+	    // when
+	    BufferedImage thumbnail = new FixedSizeThumbnailMaker(200, 200)
+	    .keepAspectRatio(true)
+	    .fitWithinDimensions(true)
+	    .scaleUp(false)
+	    .make(img);
+
+	    // then
+	    assertEquals(100, thumbnail.getWidth());
+	    assertEquals(99, thumbnail.getHeight());
+	}
+
+    @Test
+    public void scaledUp_ScaleUpDisabledFitWithinOnlyOneDimension()
+    {
+        // given
+        BufferedImage img = new BufferedImageBuilder(400, 100).build();
+
+        // when
+        BufferedImage thumbnail = new FixedSizeThumbnailMaker(200, 200)
+        .keepAspectRatio(true)
+        .fitWithinDimensions(true)
+        .scaleUp(false)
+        .make(img);
+
+        // then
+        assertEquals(200, thumbnail.getWidth());
+        assertEquals(50, thumbnail.getHeight());
+    }
 }

--- a/src/test/java/net/coobird/thumbnailator/tasks/FileThumbnailTaskTest.java
+++ b/src/test/java/net/coobird/thumbnailator/tasks/FileThumbnailTaskTest.java
@@ -48,6 +48,7 @@ public class FileThumbnailTaskTest
 				new Dimension(50, 50),
 				null,
 				true,
+				true,
 				"jpg",
 				ThumbnailParameter.DEFAULT_FORMAT_TYPE,
 				ThumbnailParameter.DEFAULT_QUALITY,
@@ -86,6 +87,7 @@ public class FileThumbnailTaskTest
 		ThumbnailParameter param = new ThumbnailParameter(
 				new Dimension(50, 50),
 				null,
+				true,
 				true,
 				"jpg",
 				ThumbnailParameter.DEFAULT_FORMAT_TYPE,

--- a/src/test/java/net/coobird/thumbnailator/tasks/StreamThumbnailTaskTest.java
+++ b/src/test/java/net/coobird/thumbnailator/tasks/StreamThumbnailTaskTest.java
@@ -55,6 +55,7 @@ public class StreamThumbnailTaskTest
 				new Dimension(50, 50),
 				null,
 				true,
+				true,
 				"png",
 				ThumbnailParameter.DEFAULT_FORMAT_TYPE,
 				ThumbnailParameter.DEFAULT_QUALITY,
@@ -88,6 +89,7 @@ public class StreamThumbnailTaskTest
 				new Dimension(50, 50),
 				null,
 				true,
+				false,
 				"png",
 				ThumbnailParameter.DEFAULT_FORMAT_TYPE,
 				ThumbnailParameter.DEFAULT_QUALITY,
@@ -129,6 +131,7 @@ public class StreamThumbnailTaskTest
 		ThumbnailParameter param = new ThumbnailParameter(
 				new Dimension(50, 50),
 				null,
+				true,
 				true,
 				"png",
 				ThumbnailParameter.DEFAULT_FORMAT_TYPE,


### PR DESCRIPTION
This option lets client select whether to generate a thumbnail when it
would scale up the image instead.

It is enabled by default (current behaviour), if client wants to generate
a thumbnail only unless the image is going to scale up, just set 'scaleUp'
to false and the image size won't change.

See #87, #85
