### PR TITLE
Disable doclint when using JDK 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,17 @@
       <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
     </repository>
   </distributionManagement>
+  <profiles>
+    <profile>
+      <id>doclint-java8-disable</id>
+      <activation>
+        <jdk>[1.8,)</jdk>
+      </activation>
+      <properties>
+        <javadoc.opts>-Xdoclint:none</javadoc.opts>
+      </properties>
+    </profile>
+  </profiles>
   <build>
     <plugins>
       <plugin>
@@ -78,6 +89,9 @@
             <goals>
               <goal>jar</goal>
             </goals>
+            <configuration>
+              <additionalparam>${javadoc.opts}</additionalparam>
+            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
When generating JavaDoc with JDK 8, it complains about JavaDoc structure.

Disabling doclint lets you generate a version using JDK 8.
