### PR TITLE
Add functionality to generate thumbnails with a fixed-size frame

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>net.coobird</groupId>
   <artifactId>thumbnailator</artifactId>
-  <version>0.4.20</version>
+  <version>0.4.21</version>
   <packaging>jar</packaging>
   <name>thumbnailator</name>
   <description>Thumbnailator - a thumbnail generation library for Java</description>

--- a/src/main/java/net/coobird/thumbnailator/ThumbnailParameter.java
+++ b/src/main/java/net/coobird/thumbnailator/ThumbnailParameter.java
@@ -24,14 +24,15 @@
 
 package net.coobird.thumbnailator;
 
+import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.image.BufferedImage;
 import java.util.ArrayList;
 import java.util.List;
 
 import net.coobird.thumbnailator.filters.ImageFilter;
-import net.coobird.thumbnailator.resizers.FixedResizerFactory;
 import net.coobird.thumbnailator.geometry.Region;
+import net.coobird.thumbnailator.resizers.FixedResizerFactory;
 import net.coobird.thumbnailator.resizers.Resizer;
 import net.coobird.thumbnailator.resizers.ResizerFactory;
 
@@ -193,6 +194,16 @@ public class ThumbnailParameter {
 	 * thumbnails.
 	 */
 	private final boolean useExifOrientation;
+
+    /**
+     * Indicated whether or not the thumbnail should be scaled to fit a fixed size (frame) background.
+     */
+    private final boolean useFrame;
+
+    /**
+     * The background color of the frame, if thumbnail will be produced with frame.
+     */
+    private final Color frameColor;
 	
 	/**
 	 * Private constructor which sets all the required fields, and performs
@@ -270,6 +281,9 @@ public class ThumbnailParameter {
 	 * 								If {@code true} is specified, then the
 	 * 								Exif metadata will be used to determine
 	 * 								the orientation of the thumbnail.
+     * @param useFrame				Whether or not, the thumbnail should be scaled to
+     *                              fit a fixed size (frame) background.
+     * @param frameColor            The background color of the frame.
 	 * 
 	 * @throws IllegalArgumentException 	If the scaling factor is not a
 	 * 										rational number or is less than or
@@ -289,7 +303,9 @@ public class ThumbnailParameter {
 			List<ImageFilter> filters,
 			ResizerFactory resizerFactory,
 			boolean fitWithinDimensions,
-			boolean useExifOrientation
+			boolean useExifOrientation,
+            boolean useFrame,
+            Color frameColor
 	) {
 		// The following 2 fields are set by the public constructors.
 		this.thumbnailSize = thumbnailSize;
@@ -332,6 +348,8 @@ public class ThumbnailParameter {
 		this.resizerFactory = resizerFactory;
 		this.fitWithinDimensions = fitWithinDimensions;
 		this.useExifOrientation = useExifOrientation;
+        this.useFrame = useFrame;
+        this.frameColor = frameColor;
 	}
 	
 	/**
@@ -428,6 +446,9 @@ public class ThumbnailParameter {
 	 * 								If {@code true} is specified, then the
 	 * 								Exif metadata will be used to determine
 	 * 								the orientation of the thumbnail.
+     * @param useFrame              Whether or not, the thumbnail should be scaled to
+     *                              fit a fixed size (frame) background.
+     * @param frameColor            The background color of the frame.
 	 *
 	 * @throws IllegalArgumentException 	If size is {@code null} or if the
 	 * 										dimensions are negative, or if the
@@ -445,7 +466,9 @@ public class ThumbnailParameter {
 			List<ImageFilter> filters,
 			Resizer resizer,
 			boolean fitWithinDimensions,
-			boolean useExifOrientation
+			boolean useExifOrientation,
+            boolean useFrame,
+            Color frameColor
 	) {
 		this(
 				thumbnailSize,
@@ -460,7 +483,9 @@ public class ThumbnailParameter {
 				filters,
 				new FixedResizerFactory(resizer),
 				fitWithinDimensions,
-				useExifOrientation
+				useExifOrientation,
+                useFrame,
+                frameColor
 		);
 		
 		validateThumbnailSize();
@@ -538,6 +563,9 @@ public class ThumbnailParameter {
 	 * 								If {@code true} is specified, then the
 	 * 								Exif metadata will be used to determine
 	 * 								the orientation of the thumbnail.
+     * @param useFrame				Whether or not, the thumbnail should be scaled to
+     *                              fit a fixed size (frame) background.
+     * @param frameColor            The background color of the frame.
 	 * 
 	 * @throws IllegalArgumentException 	If the scaling factor is not a
 	 * 										rational number or is less than or
@@ -557,7 +585,9 @@ public class ThumbnailParameter {
 			List<ImageFilter> filters,
 			Resizer resizer,
 			boolean fitWithinDimensions,
-			boolean useExifOrientation
+			boolean useExifOrientation,
+            boolean useFrame,
+            Color frameColor
 	) {
 		this(
 				null,
@@ -572,7 +602,9 @@ public class ThumbnailParameter {
 				filters,
 				new FixedResizerFactory(resizer),
 				fitWithinDimensions,
-				useExifOrientation
+				useExifOrientation,
+                useFrame,
+                frameColor
 		);
 		
 		validateScalingFactor();
@@ -646,6 +678,9 @@ public class ThumbnailParameter {
 	 * 								If {@code true} is specified, then the
 	 * 								Exif metadata will be used to determine
 	 * 								the orientation of the thumbnail.
+     * @param useFrame				Whether or not, the thumbnail should be scaled to
+     *                              fit a fixed size (frame) background.
+     * @param frameColor            The background color of the frame.
 	 * 
 	 * @throws IllegalArgumentException 	If size is {@code null} or if the
 	 * 										dimensions are negative, or if the
@@ -663,7 +698,9 @@ public class ThumbnailParameter {
 			List<ImageFilter> filters,
 			ResizerFactory resizerFactory,
 			boolean fitWithinDimensions,
-			boolean useExifOrientation
+			boolean useExifOrientation,
+            boolean useFrame,
+            Color frameColor
 	) {
 		this(
 				thumbnailSize,
@@ -678,7 +715,9 @@ public class ThumbnailParameter {
 				filters,
 				resizerFactory,
 				fitWithinDimensions,
-				useExifOrientation
+				useExifOrientation,
+                useFrame,
+                frameColor
 		);
 		
 		validateThumbnailSize();
@@ -757,6 +796,9 @@ public class ThumbnailParameter {
 	 * 								If {@code true} is specified, then the
 	 * 								Exif metadata will be used to determine
 	 * 								the orientation of the thumbnail.
+     * @param useFrame				Whether or not, the thumbnail should be scaled to
+     *                              fit a fixed size (frame) background.
+     * @param frameColor            The background color of the frame.
 	 * 
 	 * @throws IllegalArgumentException 	If the scaling factor is not a
 	 * 										rational number or is less than or
@@ -776,7 +818,9 @@ public class ThumbnailParameter {
 			List<ImageFilter> filters,
 			ResizerFactory resizerFactory,
 			boolean fitWithinDimensions,
-			boolean useExifOrientation
+			boolean useExifOrientation,
+            boolean useFrame,
+            Color frameColor
 	) {
 		this(
 				null,
@@ -791,7 +835,9 @@ public class ThumbnailParameter {
 				filters,
 				resizerFactory,
 				fitWithinDimensions,
-				useExifOrientation
+				useExifOrientation,
+                useFrame,
+                frameColor
 		);
 		
 		validateScalingFactor();
@@ -993,4 +1039,25 @@ public class ThumbnailParameter {
 	public boolean useExifOrientation() {
 		return useExifOrientation;
 	}
+
+
+    /**
+     * Whether or not, the thumbnail should be scaled to fit a fixed size (frame) background.
+     *
+     * @return      {@code true} is returned when thumbnail should be generated in a frame.
+	 * @since	0.4.21
+     */
+    public boolean useFrame() {
+        return useFrame;
+    }
+
+    /**
+     * The background color of the frame
+     *
+     * @return      The background color of the frame, if thumbnail should be generated in a frame
+	 * @since	0.4.21
+     */
+    public Color frameColor() {
+        return frameColor;
+    }
 }

--- a/src/main/java/net/coobird/thumbnailator/Thumbnailator.java
+++ b/src/main/java/net/coobird/thumbnailator/Thumbnailator.java
@@ -43,6 +43,7 @@ import net.coobird.thumbnailator.filters.ImageFilter;
 import net.coobird.thumbnailator.filters.Pipeline;
 import net.coobird.thumbnailator.filters.SwapDimensions;
 import net.coobird.thumbnailator.makers.FixedSizeThumbnailMaker;
+import net.coobird.thumbnailator.makers.FramedThumbnailMaker;
 import net.coobird.thumbnailator.makers.ScaledThumbnailMaker;
 import net.coobird.thumbnailator.name.Rename;
 import net.coobird.thumbnailator.resizers.DefaultResizerFactory;
@@ -101,8 +102,23 @@ public final class Thumbnailator {
 		boolean isSwapDimensions = hasSwapDimensionsFilter(param.getImageFilters());
 
 		BufferedImage destinationImage;
-		
-		if (param.getSize() != null) {
+
+        if (param.useFrame()) {
+            // Get the dimensions of the original and thumbnail images.
+            int destinationWidth = param.getSize().width;
+            int destinationHeight = param.getSize().height;
+
+            // Create the thumbnail.
+            destinationImage =
+                new FramedThumbnailMaker(destinationWidth, destinationHeight)
+                    .keepAspectRatio(param.isKeepAspectRatio())
+                    .fitWithinDimensions(param.fitWithinDimenions())
+                    .frameColor(param.frameColor())
+                    .imageType(imageType)
+                    .resizerFactory(param.getResizerFactory())
+                    .make(sourceImage);
+
+        } else if (param.getSize() != null) {
 			// Get the dimensions of the original and thumbnail images.
 			Dimension size = param.getSize();
 			int destinationWidth = !isSwapDimensions ? size.width : size.height;

--- a/src/main/java/net/coobird/thumbnailator/Thumbnails.java
+++ b/src/main/java/net/coobird/thumbnailator/Thumbnails.java
@@ -24,6 +24,7 @@
 
 package net.coobird.thumbnailator;
 
+import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Rectangle;
 import java.awt.RenderingHints;
@@ -691,6 +692,8 @@ instance.asFiles("path/to/thumbnail");
 			ALLOW_OVERWRITE("allowOverwrite"),
 			CROP("crop"),
 			USE_EXIF_ORIENTATION("useExifOrientation"),
+            USE_FRAME("useFrame"),
+            FRAME_COLOR("frameColor")
 			;
 			
 			private final String name;
@@ -733,6 +736,8 @@ instance.asFiles("path/to/thumbnail");
 			statusMap.put(Properties.ALLOW_OVERWRITE, Status.OPTIONAL);
 			statusMap.put(Properties.CROP, Status.OPTIONAL);
 			statusMap.put(Properties.USE_EXIF_ORIENTATION, Status.OPTIONAL);
+            statusMap.put(Properties.USE_FRAME, Status.OPTIONAL);
+            statusMap.put(Properties.FRAME_COLOR, Status.OPTIONAL);
 		}
 
 		/**
@@ -800,6 +805,10 @@ instance.asFiles("path/to/thumbnail");
 		private boolean fitWithinDimenions = true;
 		
 		private boolean useExifOrientation = true;
+
+        private boolean useFrame = false;
+
+        private Color frameColor = Color.WHITE;
 		
 		/**
 		 * This field should be set to the {@link Position} to be used for
@@ -1702,6 +1711,25 @@ Thumbnails.of(image)
 			this.useExifOrientation = useExifOrientation;
 			return this;
 		}
+
+        public Builder<T> frame(int width, int height) {
+            updateStatus(Properties.SIZE, Status.ALREADY_SET);
+            updateStatus(Properties.SCALE, Status.CANNOT_SET);
+            updateStatus(Properties.USE_FRAME, Status.ALREADY_SET);
+
+            validateDimensions(width, height);
+            this.width = width;
+            this.height = height;
+            this.useFrame = true;
+            return this;
+        }
+
+        public Builder<T> frameColor(Color color) {
+            updateStatus(Properties.FRAME_COLOR, Status.ALREADY_SET);
+
+            this.frameColor = color;
+            return this;
+        }
 		
 		/**
 		 * Indicates that the output format should be determined from the
@@ -2134,7 +2162,9 @@ watermark(Positions.CENTER, image, opacity);
 						filterPipeline.getFilters(),
 						resizerFactory,
 						fitWithinDimenions,
-						useExifOrientation
+						useExifOrientation,
+                        useFrame,
+                        frameColor
 				);
 
 			} else {
@@ -2151,7 +2181,9 @@ watermark(Positions.CENTER, image, opacity);
 						filterPipeline.getFilters(),
 						resizerFactory,
 						fitWithinDimenions,
-						useExifOrientation
+						useExifOrientation,
+                        useFrame,
+                        frameColor
 				);
 			}
 		}

--- a/src/main/java/net/coobird/thumbnailator/builders/ThumbnailParameterBuilder.java
+++ b/src/main/java/net/coobird/thumbnailator/builders/ThumbnailParameterBuilder.java
@@ -24,6 +24,7 @@
 
 package net.coobird.thumbnailator.builders;
 
+import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.image.BufferedImage;
 import java.util.Collections;
@@ -98,6 +99,8 @@ public final class ThumbnailParameterBuilder {
 	private Region sourceRegion = null;
 	private boolean fitWithinDimensions = true;
 	private boolean useExifOrientation = true;
+    private boolean useFrame;
+    private Color frameColor;
 	
 	/**
 	 * Creates an instance of a {@link ThumbnailParameterBuilder}.
@@ -347,6 +350,31 @@ public final class ThumbnailParameterBuilder {
 		return this;
 	}
 
+    /**
+     * Sets whether or not, the thumbnail should be scaled to fit a fixed size (frame) background.
+     *
+     * @param useFrame  {@code true} if the thumbnail should be generated
+     *                  in a frame, {@code false} otherwise.
+     * @return          A reference to this object.
+     * @since	0.4.21
+     */
+    public ThumbnailParameterBuilder useFrame(boolean useFrame) {
+        this.useFrame = useFrame;
+        return this;
+    }
+
+    /**
+     * Sets the background color of the frame.
+     *
+     * @param frameColor    The background color of the frame.
+     * @return              A reference to this object.
+     * @since	0.4.21
+     */
+    public ThumbnailParameterBuilder frameColor(Color frameColor) {
+        this.frameColor = frameColor;
+        return this;
+    }
+
 	/**
 	 * Returns a {@link ThumbnailParameter} from the parameters which are
 	 * currently set.
@@ -374,7 +402,9 @@ public final class ThumbnailParameterBuilder {
 					filters,
 					resizerFactory,
 					fitWithinDimensions,
-					useExifOrientation
+					useExifOrientation,
+                    useFrame,
+                    frameColor
 			);
 
 		} else if (width != UNINITIALIZED && height != UNINITIALIZED) {
@@ -389,7 +419,9 @@ public final class ThumbnailParameterBuilder {
 					filters,
 					resizerFactory,
 					fitWithinDimensions,
-					useExifOrientation
+					useExifOrientation,
+                    useFrame,
+                    frameColor
 			);
 		} else {
 			throw new IllegalStateException(

--- a/src/main/java/net/coobird/thumbnailator/makers/FixedSizeThumbnailMaker.java
+++ b/src/main/java/net/coobird/thumbnailator/makers/FixedSizeThumbnailMaker.java
@@ -71,7 +71,7 @@ BufferedImage thumbnail = new FixedSizeThumbnailMaker()
  * @author coobird
  *
  */
-public final class FixedSizeThumbnailMaker extends ThumbnailMaker {
+public class FixedSizeThumbnailMaker extends ThumbnailMaker {
 	private static final String PARAM_SIZE = "size";
 	private static final String PARAM_KEEP_RATIO = "keepRatio";
 	private static final String PARAM_FIT_WITHIN = "fitWithinDimensions";
@@ -303,4 +303,12 @@ public final class FixedSizeThumbnailMaker extends ThumbnailMaker {
 		
 		return super.makeThumbnail(img, targetWidth, targetHeight);
 	}
+
+    protected int getWidth() {
+        return width;
+    }
+
+    protected int getHeight() {
+        return height;
+    }
 }

--- a/src/main/java/net/coobird/thumbnailator/makers/FramedThumbnailMaker.java
+++ b/src/main/java/net/coobird/thumbnailator/makers/FramedThumbnailMaker.java
@@ -1,0 +1,73 @@
+package net.coobird.thumbnailator.makers;
+
+import static java.awt.image.BufferedImage.TYPE_INT_ARGB;
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+
+import net.coobird.thumbnailator.builders.BufferedImageBuilder;
+import net.coobird.thumbnailator.filters.Watermark;
+import net.coobird.thumbnailator.geometry.Positions;
+
+/**
+ * @author Panos Bariamis (pbaris)
+ */
+public final class FramedThumbnailMaker extends FixedSizeThumbnailMaker {
+
+    private static final String PARAM_USE_FRAME = "useFrame";
+    private static final String PARAM_FRAME_COLOR = "frameColor";
+
+    private Color frameColor;
+
+    public FramedThumbnailMaker(int width, int height) {
+        super(width, height);
+        ready.set(PARAM_USE_FRAME);
+        ready.unset(PARAM_FRAME_COLOR);
+    }
+
+    public FramedThumbnailMaker frameColor(Color color) {
+        if (ready.isSet(PARAM_FRAME_COLOR)) {
+            throw new IllegalStateException("The frame color has already been set.");
+        }
+
+        if (color == null) {
+            throw new IllegalArgumentException("Color it's not an instance");
+        }
+
+        this.frameColor = color;
+
+        ready.set(PARAM_FRAME_COLOR);
+        return this;
+    }
+
+    @Override
+    public FramedThumbnailMaker size(int width, int height) {
+        return (FramedThumbnailMaker)super.size(width, height);
+    }
+
+    @Override
+    public FramedThumbnailMaker keepAspectRatio(boolean keep) {
+        return (FramedThumbnailMaker)super.keepAspectRatio(keep);
+    }
+
+    @Override
+    public FramedThumbnailMaker fitWithinDimensions(boolean fit) {
+        return (FramedThumbnailMaker)super.fitWithinDimensions(fit);
+    }
+
+    @Override
+    public BufferedImage make(BufferedImage img) {
+        BufferedImage framedImage = new BufferedImageBuilder(getWidth(), getHeight(), TYPE_INT_ARGB).build();
+        Graphics2D g = framedImage.createGraphics();
+        g.setColor(frameColor);
+        g.fillRect(0, 0, getWidth(), getHeight());
+        g.dispose();
+
+        img = super.make(img);
+        Watermark wm = new Watermark(Positions.CENTER, img, 1.0f);
+        framedImage = wm.apply(framedImage);
+
+        return framedImage;
+    }
+}

--- a/src/test/java/net/coobird/thumbnailator/tasks/FileThumbnailTaskTest.java
+++ b/src/test/java/net/coobird/thumbnailator/tasks/FileThumbnailTaskTest.java
@@ -24,24 +24,25 @@
 
 package net.coobird.thumbnailator.tasks;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.awt.Dimension;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
+import javax.imageio.ImageIO;
 
 import net.coobird.thumbnailator.TestUtils;
 import net.coobird.thumbnailator.ThumbnailParameter;
 import net.coobird.thumbnailator.builders.BufferedImageBuilder;
 import net.coobird.thumbnailator.resizers.Resizers;
-
 import net.coobird.thumbnailator.test.BufferedImageComparer;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-
-import javax.imageio.ImageIO;
 
 public class FileThumbnailTaskTest {
 
@@ -81,7 +82,9 @@ public class FileThumbnailTaskTest {
 				null,
 				Resizers.PROGRESSIVE,
 				true,
-				true
+				true,
+                false,
+                null
 		);
 		
 		File inputFile = TestUtils.copyResourceToTemporaryFile(
@@ -109,7 +112,9 @@ public class FileThumbnailTaskTest {
 				null,
 				Resizers.PROGRESSIVE,
 				true,
-				true
+				true,
+                false,
+                null
 		);
 
 		// When inputFile is read, then an exception should be thrown.
@@ -139,7 +144,9 @@ public class FileThumbnailTaskTest {
 				null,
 				Resizers.PROGRESSIVE,
 				true,
-				true
+				true,
+                false,
+                null
 		);
 
 		// When inputFile is read, then an exception should be thrown.

--- a/src/test/java/net/coobird/thumbnailator/tasks/StreamThumbnailTaskTest.java
+++ b/src/test/java/net/coobird/thumbnailator/tasks/StreamThumbnailTaskTest.java
@@ -86,7 +86,9 @@ public class StreamThumbnailTaskTest {
 				null,
 				Resizers.PROGRESSIVE,
 				true,
-				true
+				true,
+                false,
+                null
 		);
 		
 		File inputFile = TestUtils.copyResourceToTemporaryFile(
@@ -119,7 +121,9 @@ public class StreamThumbnailTaskTest {
 				null,
 				Resizers.PROGRESSIVE,
 				true,
-				true
+				true,
+                false,
+                null
 		);
 
 		File inputFile = TestUtils.copyResourceToTemporaryFile(
@@ -155,7 +159,9 @@ public class StreamThumbnailTaskTest {
 				null,
 				Resizers.PROGRESSIVE,
 				true,
-				true
+				true,
+                false,
+                null
 		);
 		
 		InputStream is = mock(InputStream.class);


### PR DESCRIPTION
Implementation allows thumbnail generation to be framed with a fixed size (dimension), and the color of the frame can be set. The changes add two new parameters to the thumbnail generation - "useFrame" and "frameColor" - while retaining backward compatibility with the existing functions. A new class, "FramedThumbnailMaker," has been created to handle the framing. Also, increased minor version of the library.

**Hello! Thank you for your interest in contributing to Thumbnailator!**

Unfortunately, I'm not accepting pull requests at this moment.

Contributions in the form of bugs reports or feature enhancements through
[issues](https://github.com/coobird/thumbnailator/issues) are appreciated.
